### PR TITLE
Add support for mermaid diagram visualizations

### DIFF
--- a/mkdocs.hdr.yml
+++ b/mkdocs.hdr.yml
@@ -14,8 +14,19 @@ theme:
     accent: "indigo"
 extra:
   repo_icon: github
+extra_javascript:
+  - https://unpkg.com/mermaid@8.8.4/dist/mermaid.min.js
+plugins:
+  - search
+  - mermaid2:
+      version: 8.8.4
 markdown_extensions:
-  - codehilite
+  - pymdownx.inlinehilite
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:mermaid2.fence_mermaid
   - toc:
       permalink: true
 nav:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 setuptools
 mkdocs-material
+mkdocs-mermaid2-plugin


### PR DESCRIPTION
Add support for mermaid diagram visualizations in rfc content.

As a side effect the `codehilite` mkdocs etension is replaced with `pymdownx`
but works the same in practice.